### PR TITLE
Refactor uat parameters to update database and app service names

### DIFF
--- a/parameters/uat.parameters.json
+++ b/parameters/uat.parameters.json
@@ -6,10 +6,10 @@
             "value": "nonprod"
         },
         "postgreSQLServerName": {
-            "value": "forfaly-dbsrv-uat"
+            "value": "forfaly1-dbsrv-uat"
         },
         "postgreSQLDatabaseName": {
-            "value": "forfaly-db-uat"
+            "value": "forfaly1-db-uat"
         },
         "appServicePlanName": {
             "value": "forfaly-asp-uat"


### PR DESCRIPTION
This pull request includes a refactoring of the UAT parameters to update the names of the database and app service. The PostgreSQL server name has been changed to "forfaly1-dbsrv-uat" and the PostgreSQL database name has been changed to "forfaly1-db-uat". This update ensures that the UAT environment is using the correct database and app service names.